### PR TITLE
rework 'strip_option' to accept full paths ending with ::Option, rather than just Option.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,14 +227,12 @@ fn generate_setter_method(
     let mut stripped_option = false;
     if def.strip_option {
         if let Type::Path(path) = &field_ty {
-            if path.path.segments.len() == 1 {
-                let segment = path.path.segments.first().unwrap();
-                if segment.ident.to_string() == "Option" {
-                    if let PathArguments::AngleBracketed(path) = &segment.arguments {
-                        if let GenericArgument::Type(tp) = path.args.first().unwrap() {
-                            field_ty = tp.clone();
-                            stripped_option = true;
-                        }
+            let segment = path.path.segments.last().unwrap();
+            if segment.ident.to_string() == "Option" {
+                if let PathArguments::AngleBracketed(path) = &segment.arguments {
+                    if let GenericArgument::Type(tp) = path.args.first().unwrap() {
+                        field_ty = tp.clone();
+                        stripped_option = true;
                     }
                 }
             }

--- a/tests/basics.rs
+++ b/tests/basics.rs
@@ -77,18 +77,20 @@ fn generic_struct() {
 #[setters(strip_option)]
 struct StripOptionStruct {
     a: Option<u32>,
-    b: u32,
+    b: core::option::Option<u32>,
+    c: std::option::Option<u32>,
+    d: u32,
 }
 
 #[test]
 fn strip_option_struct() {
     assert_eq!(
-        StripOptionStruct::default().a(3).b(6),
-        StripOptionStruct { a: Some(3), b: 6 },
+        StripOptionStruct::default().a(3).b(42).c(43).d(7),
+        StripOptionStruct { a: Some(3), b: Some(42), c : Some(43), d: (7) },
     );
     assert_eq!(
         StripOptionStruct::default().b(6),
-        StripOptionStruct { a: None, b: 6 },
+        StripOptionStruct { a: None, b: Some(6) , c: None, d: 0},
     );
 }
 


### PR DESCRIPTION
should work better with other proc macros that use full paths.