### PR TITLE
Use `proc_macro2::Span` instead of `syn::export::Span`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,10 +5,9 @@ extern crate proc_macro;
 use darling::*;
 use darling::util::Flag;
 use proc_macro::TokenStream;
-use proc_macro2::{TokenStream as SynTokenStream};
+use proc_macro2::{Span, TokenStream as SynTokenStream};
 use std::result::Result;
 use syn::*;
-use syn::export::Span;
 use syn::spanned::Spanned;
 use quote::*;
 


### PR DESCRIPTION
In a [recent commit](https://github.com/dtolnay/syn/commit/957840eba2c7f11c95e0227760d78dc481a91de7) in the `syn` crate, the `export` module was renamed which results in build errors for this crate since it uses `syn::export::Span`. The `Span` struct from `syn` is just a re-export of `proc_macro2::Span` which means it can be used directly.