### PR TITLE
Add option to prefix delegated setters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derive_setters"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Lymia Aluysia <lymia@lymiahugs.com>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ The following options can be set on the entire struct.
   be duplicated on the target struct, instead modifying `self.some_field` instead of `self`.
 * `#[setters(generate_delegates(ty = "OtherTy", method = "get_field"))]` does the same thing as above, except calling
   `get_field` with no arguments instead of directly accessing a field.
+* `#[setters(generate_delegates(ty = "OtherTy", field = "some_field", prefix = "set_"))]` adds the prefix "set_" to all
+  delegated fields.
 
 The following options can be set on a fields.
 

--- a/tests/basics.rs
+++ b/tests/basics.rs
@@ -5,6 +5,7 @@ use std::borrow::Cow;
 #[derive(Default, Setters, Debug, PartialEq, Eq)]
 #[setters(generate_delegates(ty = "BasicDelegateField", field = "x"))]
 #[setters(generate_delegates(ty = "BasicDelegateMethod", method = "get_x"))]
+#[setters(generate_delegates(ty = "PrefixBasicDelegateField", field = "x", prefix = "with_"))]
 struct BasicStruct {
     #[setters(rename = "test")]
     a: u32,
@@ -30,6 +31,11 @@ impl BasicDelegateMethod {
     }
 }
 
+#[derive(Default, Debug, PartialEq, Eq)]
+struct PrefixBasicDelegateField {
+    x: BasicStruct,
+}
+
 #[test]
 fn basic_struct() {
     assert_eq!(
@@ -52,6 +58,10 @@ fn delegated_structs() {
         BasicDelegateMethod::default().b(15).test(10),
         BasicDelegateMethod { x: Some(BasicStruct { a: 10, b: 15, ..Default::default() }) },
     );
+    assert_eq!(
+        PrefixBasicDelegateField::default().with_b(15).with_test(10),
+        PrefixBasicDelegateField { x: BasicStruct { a: 10, b: 15, ..Default::default() } },
+    )
 }
 
 #[derive(Default, Setters, Debug, PartialEq, Eq)]


### PR DESCRIPTION
This PR adds a `prefix` option to `generate_delegate` which adds a prefix to all the setters delegated. For example, if you have this situation:

```rust
#[derive(Setters)]
#[setters(generate_delegates(ty = "PrefixBasicDelegateField", field = "x", prefix = "with_"))]
struct BasicStruct {
    a: u32,
    b: u32,
    c: u32,
}

struct PrefixBasicDelegateField {
    x: BasicStruct,
}
```

Then the struct `PrefixBasicDelegateField` would have the setter functions `with_a`, `with_b`, and `with_c`.