### PR TITLE
Fix clippy::needless_update

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -312,8 +312,9 @@ fn generate_setter_method(
         } else {
             Ok(quote! {
                 #field_doc
-                pub fn #setter_name (self, #params) -> Self {
-                    #container_name { #field_name: #expr, ..self }
+                pub fn #setter_name (mut self, #params) -> Self {
+                    self.#field_name = #expr;
+                    self
                 }
             })
         }


### PR DESCRIPTION
If the struct has only one field, Code like this triggers clippy::needless_update warning:

```rust
pub fn foo(self, value: i32) -> Self {
  Self { value: value, ..self }
}
```

This commit generate code like this:

```rust
pub fn foo(mut self, value: i32) -> Self {
   self.value = value;
   self
}
```